### PR TITLE
corrected examples/package.json so that it is valid

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "sftp-ws samples",
+  "name": "sftp-ws-samples",
   "version": "0.3.0",
   "description": "Sample code for sftp-ws package",
   "dependencies": {
 	"sftp-ws": "~0.3.0",
-    "express": "4.10.x", 
+    "express": "4.10.x" 
   }
 }


### PR DESCRIPTION
The examples/package.json had one extra comma and an invalid package name.
